### PR TITLE
Compress compiled block using { unsued: "keep_assign" }

### DIFF
--- a/lib/cwise-transform.js
+++ b/lib/cwise-transform.js
@@ -11,7 +11,7 @@ var OPTIONAL_FIELDS = [ "pre", "post", "printCode", "funcName", "blockSize" ]
 
 function processFunc(func) {
   var codeStr = "var X=" + func
-  var minified = uglify.minify(codeStr, {fromString: true}).code
+  var minified = uglify.minify(codeStr, {fromString: true, compress: { unused: "keep_assign" }}).code
   var code = minified.substr(6, minified.length-7)
   return parse(code)
 }

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -5,7 +5,7 @@ var vm = require("vm")
 var path = require("path")
 var tape = require("tape")
 
-var cases = [ "unary", "binary", "offset" ]
+var cases = [ "unary", "binary", "offset", "fill" ]
 
 bundleCasesFrom(0)
 

--- a/test/fill.js
+++ b/test/fill.js
@@ -1,0 +1,42 @@
+var cwise = require("cwise")
+var ndarray = require("ndarray")
+
+if(typeof test === "undefined") {
+  test = require("tape")
+}
+
+test("fill", function(t) {
+
+  var fill = cwise({
+    args: ["index", "array", "scalar"],
+    body: function(idx, out, f) {
+      out = f.apply(undefined, idx)
+    }
+  })
+
+  var xlen = 10
+  var ylen = 5
+  var array = ndarray(new Float32Array(xlen * ylen), [xlen, ylen])
+
+  fill(array, function(row, col) {
+    return 0
+  })
+
+  for(var i = 0; i < xlen; i++) {
+    for(var j = 0; j < ylen; j++) {
+      t.equals(array.get(i, j), 0, 'fill ('+ i + ',' + j + ')')
+    }
+  }
+
+  fill(array, function(row, col) {
+    return 10 * (row + col)
+  })
+
+  for(var i = 0; i < xlen; i++) {
+    for(var j = 0; j < ylen; j++) {
+      t.equals(array.get(i, j), 10 * (i + j), 'fill ('+ i + ',' + j + ')')
+    }
+  }
+
+  t.end()
+})


### PR DESCRIPTION
This PR fixes a bug showing in browserify-transformed `ndarray-fill` with `uglify-js@2.8.x`.

This bug was first reported in https://github.com/plotly/plotly.js/pull/1450#issuecomment-284803443 and was introduced in https://github.com/mishoo/UglifyJS2/pull/1450 which was published as part of `uglify-js@2.8.0`. For more info on the `{ unused: "keep_assign" }` rule see the compressor [options](https://github.com/mishoo/UglifyJS2#compressor-options). In essence, without that `unused` setting the compiled [block](https://github.com/scijs/cwise/blob/35f89e209b9cf024857149cf55943de55c12d840/lib/cwise-transform.js#L42) removes the `_inline_1_arg1_` references:

![image](https://cloud.githubusercontent.com/assets/6675409/23876550/615d9844-0814-11e7-8d82-c5651ffea5c5.png)

This PR also adds tests for fill-like operations similar to [`ndarray-fill`](https://github.com/scijs/ndarray-fill/blob/master/test/test.js). 