### PR TITLE
Static eval bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ logs
 results
 
 npm-debug.log
+package-lock.json
 node_modules/*

--- a/lib/cwise-transform.js
+++ b/lib/cwise-transform.js
@@ -17,6 +17,11 @@ function processFunc(func) {
 }
 
 function cwiseTransform(file, opts) {
+  if(!opts) opts = {}
+  if(opts.allowAccessToMethodsOnFunctions !== false) {
+    opts.allowAccessToMethodsOnFunctions = true
+  }
+
   var sm = staticModule({
     cwise: function(user_args) {
       for(var id in user_args) {
@@ -42,6 +47,6 @@ function cwiseTransform(file, opts) {
       var codeStr = "require('cwise/lib/wrapper')(" + JSON.stringify(compileBlock) + ")"
       return codeStr
     }
-  })
+  }, opts)
   return sm
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "cwise-parser": "^1.0.0",
     "cwise-compiler": "^1.1.1",
-    "static-module": "^1.0.0",
+    "static-module": "git://github.com/browserify/static-module.git#3c18ee194fdb674ce590a65ace4e5e17c775733f",
     "uglify-js": "^2.6.0"
   },
   "devDependencies": {

--- a/test/fill.js
+++ b/test/fill.js
@@ -10,7 +10,7 @@ test("fill", function(t) {
   var fill = cwise({
     args: ["index", "array", "scalar"],
     body: function(idx, out, f) {
-      out = f.apply(undefined, idx)
+      out = f.apply(null, idx)
     }
   })
 


### PR DESCRIPTION
Supersedes #25.
Changes needed to bump `static-eval` once https://github.com/browserify/static-module/pull/56 merged and new `static-module` released.
cc: https://github.com/browserify/static-module/issues/48#issuecomment-644057127

@goto-bus-stop @rreusser 

P.S. this is also tested on `plotly.js` repo on this branch: https://github.com/plotly/plotly.js/compare/static-eval-bump